### PR TITLE
TURN REST API Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ npm start
 
 to start the tlk server on port 3000. Your tlk instance will be running on http://localhost:3000. Alternatively you can run the application using docker with `docker-compose up`.
 
+### How to self host it
+
+In order to self-host it on your dedicated server, Tlk must be exposed on `https` following [this documentation](./docs/self-hosting.md).
+
+You can also expose it quickly on `https` from your local PC or any host using [ngrok](https://ngrok.com/).
+
+### Using TURN REST API Authentication
+
+If you're using `coturn` - set up `use-auth-secret` and provision a secret either via `static-auth-secret` or via `turnadmin -s`
+
+Set up following environment variables:
+
+* `SHARED_SECRET`: This should match the parameter provided to coturn
+* `CUSTOM_STUN_SERVER`: `stun:stun.your.domain.name`
+* `CUSTOM_TURN_SERVER`: `turn:stun.your.domain.name`
+* `CREDENTIAL_LIFETIME`: How long should the credential be valid for (in seconds)
+
 ### LICENSE
 
 <a href="https://github.com/vasanthv/tlk/blob/master/LICENSE">MIT License</a>

--- a/www/script.js
+++ b/www/script.js
@@ -73,6 +73,11 @@ function init() {
 			});
 	});
 
+	signalingSocket.on("ice_servers", function(data) {
+		console.log('Received ICE Servers', data);
+		App.ice_servers = data;
+	});
+
 	signalingSocket.on("disconnect", function () {
 		for (let peer_id in peerMediaElements) {
 			document.getElementById("videos").removeChild(peerMediaElements[peer_id].parentNode);
@@ -99,7 +104,7 @@ function init() {
 		channel = config.channel;
 		//console.log('[Join] - connected peers in the channel', JSON.stringify(channel, null, 2));
 
-		const peerConnection = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+		const peerConnection = new RTCPeerConnection({ iceServers: App.ice_servers || ICE_SERVERS });
 		peers[peer_id] = peerConnection;
 
 		peerConnection.onicecandidate = function (event) {


### PR DESCRIPTION
Problem
=======

* If I want to use my own TURN/STUN server, this requires generating ephemeral credentials, to avoid compromising long-term credentials, as those would be exposed in the source code.

Solution
========

* Generate an ephemeral credential server-side, and provide it to each client via socket.io connection

Notes
=====

Tested against a local `coturn` server